### PR TITLE
Test for private messages

### DIFF
--- a/test/notify.coffee
+++ b/test/notify.coffee
@@ -24,6 +24,19 @@ describe 'hubot-notify', ->
         ['hubot', 'Ops is down!']
       ]
 
+  context "POST /notify/pchaigno", ->
+    beforeEach (done) ->
+      data = {message: "Oracle is down!"}
+      request.post {url: 'http://127.0.0.1:8080/notify/pchaigno', form: data}, (err, httpResponse, body) ->
+        done()
+
+    it 'notifies pchaigno by private message', ->
+      expect(@room.privateMessages).to.eql {
+        'pchaigno': [
+          ['hubot', 'Oracle is down!']
+        ]
+      }
+
   context "POST /notify/_hdbot/pchaigno", ->
     beforeEach (done) ->
       data = {message: "Gitlab is down!"}


### PR DESCRIPTION
This pull request adds a test for private messages (`POST /notify/username`).

The behavior of `robot.messageRoom` this tests - `robot.messageRoom username` sends a private message - is specific to hubot-irc. Thus, it is not currently supported by `hubot-test-helper` and the tests fail.

Needed to merge this pull request:
- [ ] expose a way to send private messages in `hubot` (via messageRoom or a dedicated method)
- [ ] add support for private messages in `hubot-test-helper`
